### PR TITLE
Fix JS typo and restore closing HTML

### DIFF
--- a/assets/js/three-js-setup.js
+++ b/assets/js/three-js-setup.js
@@ -10,7 +10,9 @@
  const scene = new THREE.Scene();
 
  // Objects
- const geometry = new THREE.SpherBufferGeometry(0.5, 65, 65);
+// Create a sphere geometry. The previous type name was misspelled and
+// prevented the scene from rendering correctly.
+const geometry = new THREE.SphereBufferGeometry(0.5, 65, 65);
 
  // Materials
  const material = new THREE.MeshStandardMaterial();
@@ -87,10 +89,13 @@
  const windowX = window.innerWidth / 2;
  const windowY = window.innerHeight / 2;
 
- function onDocumentMouseMove(event) {
-    mouseX = event.clientX = windowX;
-    mouseY = event.clientY = windowY;
- };
+function onDocumentMouseMove(event) {
+  // Capture mouse movement relative to the center of the window. The
+  // previous implementation overwrote the event properties, resulting in
+  // incorrect values.
+  mouseX = event.clientX - windowX;
+  mouseY = event.clientY - windowY;
+}
 
 
  const updateShape = (event) =>{

--- a/index.html
+++ b/index.html
@@ -123,7 +123,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdnjs.cloudflare"></script>
+    <!-- Load Three.js for the 3D background -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -175,3 +176,4 @@
     </script>
     
 </body>
+</html>


### PR DESCRIPTION
## Summary
- correct SphereBufferGeometry typo in 3D setup script
- handle mousemove correctly
- load three.js from CDN
- add missing closing `</html>` tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685407377cf88330b05ef6f89e845f42