### PR TITLE
Add responsive 'What I Build' section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,3 +30,9 @@ body {
   padding: 1rem;
   border-radius: 8px;
 }
+
+@media (max-width: 600px) {
+  .feature {
+    flex: 1 1 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -56,6 +56,23 @@
             <h2>Codex Engineer & AI Infrastructure Builder</h2>
             <p>Smart Money Tools, FastAPI Apps, and Developer Discipline.</p>
         </section>
+        <section class="what-i-build">
+          <h3>What I Build</h3>
+          <div class="features">
+            <div class="feature">
+              <h4>Codex Prompt Creator</h4>
+              <p>Modular instructions to automate FastAPI app builds.</p>
+            </div>
+            <div class="feature">
+              <h4>Chart Reader App</h4>
+              <p>Upload charts, get GPT-based structural analysis.</p>
+            </div>
+            <div class="feature">
+              <h4>BOSBOX System</h4>
+              <p>Enforces trader discipline with structural AI logic.</p>
+            </div>
+          </div>
+        </section>
         <!-- Home Section -->
         <section id="home-section" class="py-5">
             <div class="container">


### PR DESCRIPTION
## Summary
- insert a "What I Build" section below the hero banner
- style the section and add a media query so features stack on mobile screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68543539cad88330aa4dd73a4137308c