### PR TITLE
Add CTA block below hero

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -132,3 +132,30 @@ body {
     border-bottom: none;
   }
 }
+
+/* CTA Block */
+.cta-block {
+  background: #0a0a0a;
+  color: #ddd;
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.cta-block .cta-inner {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.cta-block .cta-button {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.3s, box-shadow 0.3s;
+}
+
+.cta-block .cta-button:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}

--- a/index.html
+++ b/index.html
@@ -41,6 +41,14 @@
             <h1>Simple tools. Serious edge.</h1>
             <h2>I create AI tools that demystify financial systems — so anyone can see it, learn it, and use it better.</h2>
         </section>
+
+        <section class="cta-block">
+            <div class="cta-inner">
+                <h2>Join the list. Follow the build.</h2>
+                <p>Be the first to know when new tools drop — and get early access, free.</p>
+                <a href="#" class="cta-button">&rarr; Get Early Access</a>
+            </div>
+        </section>
         <section class="what-i-build">
           <h3>What I Build</h3>
           <div class="features">


### PR DESCRIPTION
## Summary
- insert a sign-up CTA block immediately after the hero section
- style CTA block with dark background and gold button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68569e8014288330849eebfba0c1176d