### PR TITLE
Add responsive hamburger menu styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -83,6 +83,16 @@ body {
   background-color: var(--muted);
 }
 
+.nav-toggle {
+  display: none;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  color: var(--fg, #fff);
+  cursor: pointer;
+  margin-left: auto;
+}
+
 
 .nav-menu {
   display: flex;
@@ -92,10 +102,13 @@ body {
   padding: 0;
   flex-wrap: wrap;
   justify-content: center;
+  overflow: hidden;
+  max-height: 100vh;
+  transition: max-height 0.3s ease;
 }
 
 .nav-menu.collapsed {
-  display: none;
+  max-height: 0;
 }
 
 .nav-menu li {
@@ -169,17 +182,12 @@ body {
 @media (max-width: 768px) {
   .nav-menu {
     flex-direction: column;
+    align-items: center;
     text-align: center;
   }
 
   .nav-toggle {
     display: block;
-    font-size: 1.5rem;
-    background: none;
-    border: none;
-    color: var(--fg, #fff);
-    cursor: pointer;
-    margin-left: auto;
   }
 }
 
@@ -190,5 +198,6 @@ body {
 
   .nav-menu.collapsed {
     display: flex !important;
+    max-height: none;
   }
 }


### PR DESCRIPTION
## Summary
- add base styles for `.nav-toggle` button
- animate opening of mobile nav via max-height transition
- ensure collapsed menu works on desktop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68693b5bb0b88330a7248d19ed84cef4