### PR TITLE
Add muted outline around header sections

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -16,6 +16,12 @@
   padding: var(--space-sm) var(--space-md);
 }
 
+.header-left,
+.header-right,
+.nav {
+  outline: 1px solid var(--muted);
+}
+
 .nav-toggle-label {
   display: none;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- outline header-left, header-right and nav with a 1px solid muted border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ed7f77ec83309c6d754fc47aa2f1