### PR TITLE
Refactor site styling to use design tokens and cards

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -185,10 +185,44 @@
   }
 }
 
+/* Services */
+#services .card {
+  height: 100%;
+}
+
+/* Process */
+.process-step {
+  text-align: center;
+}
+
+/* Testimonials */
+.testimonial {
+  margin: 0;
+}
+
+/* Contact Form */
+#contact form label {
+  color: var(--fg);
+}
+
+#contact form input,
+#contact form textarea {
+  background-color: var(--primary);
+  color: var(--fg);
+  border: 1px solid var(--muted);
+  border-radius: var(--radius);
+}
+
+#contact form input::placeholder,
+#contact form textarea::placeholder {
+  color: var(--muted);
+}
+
 /* Footer */
 footer {
-  background-color: var(--bg);
+  background-color: var(--primary);
   color: var(--muted);
   padding: var(--space-sm);
   font-size: 0.875rem;
+  text-align: center;
 }

--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -11,6 +11,29 @@
 .font-body   { font-family: var(--font-body); }
 .font-display { font-family: var(--font-display); }
 
+.card {
+  background-color: var(--primary);
+  color: var(--fg);
+  padding: var(--space-sm);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.btn-accent {
+  display: inline-block;
+  background-color: var(--accent);
+  color: var(--primary);
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.btn-accent:hover {
+  background-color: var(--highlight);
+}
+
 /* Responsive spacing (examples only) */
 .p-sm  { padding: var(--space-sm); }
 .p-md  { padding: var(--space-md); }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <nav class="nav" aria-label="Primary">
       <ul class="nav-menu" id="primary-menu">
         <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
-        <li class="nav-item"><a class="nav-link" href="#what-we-offer">What We Offer</a></li>
+        <li class="nav-item"><a class="nav-link" href="#what-i-offer">What I Offer</a></li>
         <li class="nav-item"><a class="nav-link" href="#our-process">Our Process</a></li>
         <li class="nav-item"><a class="nav-link" href="#testimonials">Testimonials</a></li>
         <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
@@ -45,27 +45,33 @@
  
   <section id="services" class="py-5">
     <div class="container">
-      <h2 class="text-success">Services</h2>
+      <h2 class="text-primary">Services</h2>
       <div class="row">
         <div class="col-md-4">
-          <h3><a href="#">Google Growth Jumpstart – $299</a></h3>
-          <p>Kickstart your site with essential optimizations and analytics setup.</p>
+          <div class="card">
+            <h3><a href="#">Google Growth Jumpstart – $299</a></h3>
+            <p>Kickstart your site with essential optimizations and analytics setup.</p>
+          </div>
         </div>
         <div class="col-md-4">
-          <h3><a href="#">SEO Clarity Report</a></h3>
-          <p>Get a comprehensive overview of your current SEO standing.</p>
+          <div class="card">
+            <h3><a href="#">SEO Clarity Report</a></h3>
+            <p>Get a comprehensive overview of your current SEO standing.</p>
+          </div>
         </div>
         <div class="col-md-4">
-          <h3><a href="#">On-page SEO</a></h3>
-          <p>Fine-tune content and structure for higher rankings.</p>
+          <div class="card">
+            <h3><a href="#">On-page SEO</a></h3>
+            <p>Fine-tune content and structure for higher rankings.</p>
+          </div>
         </div>
       </div>
     </div>
   </section>
 
-  <section id="what-we-offer" class="py-5">
+  <section id="what-i-offer" class="py-5">
     <div class="container">
-      <h2 class="text-success">What We Offer</h2>
+      <h2 class="text-primary">What I Offer</h2>
       <p>Strategic SEO solutions to help businesses grow their online presence and increase organic traffic.</p>
       <ul>
         <li>✓ Comprehensive SEO Audits</li>
@@ -79,23 +85,31 @@
 
   <section id="our-process" class="py-5">
     <div class="container">
-      <h2 class="text-success">Our Process</h2>
+      <h2 class="text-primary">Our Process</h2>
       <div class="row text-center">
         <div class="col-md-3">
-          <h4><strong>1. Discovery</strong></h4>
-          <p>Understand client goals and perform initial analysis</p>
+          <div class="process-step card">
+            <h4><strong>1. Discovery</strong></h4>
+            <p>Understand client goals and perform initial analysis</p>
+          </div>
         </div>
         <div class="col-md-3">
-          <h4><strong>2. Strategy</strong></h4>
-          <p>Develop customized SEO roadmap</p>
+          <div class="process-step card">
+            <h4><strong>2. Strategy</strong></h4>
+            <p>Develop customized SEO roadmap</p>
+          </div>
         </div>
         <div class="col-md-3">
-          <h4><strong>3. Implementation</strong></h4>
-          <p>Execute strategic SEO tactics</p>
+          <div class="process-step card">
+            <h4><strong>3. Implementation</strong></h4>
+            <p>Execute strategic SEO tactics</p>
+          </div>
         </div>
         <div class="col-md-3">
-          <h4><strong>4. Reporting</strong></h4>
-          <p>Track performance and provide insights</p>
+          <div class="process-step card">
+            <h4><strong>4. Reporting</strong></h4>
+            <p>Track performance and provide insights</p>
+          </div>
         </div>
       </div>
     </div>
@@ -103,8 +117,8 @@
 
   <section id="testimonials" class="py-5">
     <div class="container">
-      <h2 class="text-success">Client Success Stories</h2>
-      <blockquote>
+      <h2 class="text-primary">Client Success Stories</h2>
+      <blockquote class="testimonial card">
         "Working with this team transformed our online presence. Our organic traffic increased by 187% in just 6 months!"
         <footer>– Jane Smith, CEO</footer>
       </blockquote>
@@ -113,7 +127,7 @@
 
   <section id="contact" class="py-5">
     <div class="container">
-      <h2 class="text-success">Contact</h2>
+      <h2 class="text-primary">Contact</h2>
       <form>
         <div class="mb-3">
           <label for="name" class="form-label">Name</label>
@@ -127,20 +141,20 @@
           <label for="message" class="form-label">Message</label>
           <textarea class="form-control" id="message" rows="4" placeholder="How can we help?" required></textarea>
         </div>
-        <button type="submit" class="btn btn-success">Send Message</button>
+        <button type="submit" class="btn-accent">Send Message</button>
       </form>
     </div>
   </section>
 
   <section class="py-5">
     <div class="container">
-      <h2 class="text-success">Ready to grow your business?</h2>
+      <h2 class="text-primary">Ready to grow your business?</h2>
       <p>Contact us today to learn how our SEO strategies can help you reach your business goals.</p>
     </div>
   </section>
 
-  <footer class="py-3 bg-light">
-    <div class="container text-center">
+  <footer>
+    <div class="container">
       <p>&copy; <script>document.write(new Date().getFullYear());</script> H. Hill. All Rights Reserved.</p>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- replace Bootstrap color classes with token-based utilities and rename "What I Offer" section
- display services as cards and style process steps and testimonials with design tokens
- update contact form and footer to match token-driven color scheme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc5eae208330b16ce84b5c285981