### PR TITLE
Use foreground color for headings

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -133,9 +133,6 @@
   font-size: 64px;
 }
 
-.hero .text-primary {
-  color: var(--fg);
-}
 
 /* CTA Block */
 .cta-block {

--- a/index.html
+++ b/index.html
@@ -39,13 +39,13 @@
   <main class="container-fluid">
     <section class="hero">
       <h1>Strategic SEO for Sustainable Growth</h1>
-      <h2 class="text-primary">We help businesses increase visibility and organic traffic.</h2>
+      <h2>We help businesses increase visibility and organic traffic.</h2>
     </section>
   </main>
  
   <section id="services" class="py-5">
     <div class="container">
-      <h2 class="text-primary">Services</h2>
+      <h2>Services</h2>
       <div class="row">
         <div class="col-md-4">
           <div class="card">
@@ -71,7 +71,7 @@
 
   <section id="what-i-offer" class="py-5">
     <div class="container">
-      <h2 class="text-primary">What I Offer</h2>
+      <h2>What I Offer</h2>
       <p>Strategic SEO solutions to help businesses grow their online presence and increase organic traffic.</p>
       <ul>
         <li>✓ Comprehensive SEO Audits</li>
@@ -85,7 +85,7 @@
 
   <section id="our-process" class="py-5">
     <div class="container">
-      <h2 class="text-primary">Our Process</h2>
+      <h2>Our Process</h2>
       <div class="row text-center">
         <div class="col-md-3">
           <div class="process-step card">
@@ -117,7 +117,7 @@
 
   <section id="testimonials" class="py-5">
     <div class="container">
-      <h2 class="text-primary">Client Success Stories</h2>
+      <h2>Client Success Stories</h2>
       <blockquote class="testimonial card">
         "Working with this team transformed our online presence. Our organic traffic increased by 187% in just 6 months!"
         <footer>– Jane Smith, CEO</footer>
@@ -127,7 +127,7 @@
 
   <section id="contact" class="py-5">
     <div class="container">
-      <h2 class="text-primary">Contact</h2>
+      <h2>Contact</h2>
       <form>
         <div class="mb-3">
           <label for="name" class="form-label">Name</label>
@@ -148,7 +148,7 @@
 
   <section class="py-5">
     <div class="container">
-      <h2 class="text-primary">Ready to grow your business?</h2>
+      <h2>Ready to grow your business?</h2>
       <p>Contact us today to learn how our SEO strategies can help you reach your business goals.</p>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Remove accent class from all headings so they inherit the site's foreground color
- Drop unused hero text-primary override from layout styles

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975a578dbc8330a8bf9593f5a5c7aa