### PR TITLE
Limit hero text width

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -137,6 +137,11 @@
   font-size: clamp(1.25rem, 4vw, 2rem);
 }
 
+.hero-content {
+  max-width: 60ch;
+  margin: 0 auto;
+}
+
 
 /* CTA Block */
 .cta-block {

--- a/index.html
+++ b/index.html
@@ -38,8 +38,10 @@
 
   <main class="container-fluid">
     <section class="hero">
-      <h1>Strategic SEO for Sustainable Growth</h1>
-      <h2>We help businesses increase visibility and organic traffic.</h2>
+      <div class="hero-content">
+        <h1>Strategic SEO for Sustainable Growth</h1>
+        <h2>We help businesses increase visibility and organic traffic.</h2>
+      </div>
     </section>
   </main>
  


### PR DESCRIPTION
## Summary
- Center hero text within a `hero-content` container for cleaner layout.
- Constrain hero content width to 60ch via new `.hero-content` rule.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68975f4c31608330aac9eb1f8b167136