### PR TITLE
Adjust hero heading width and golden ratio fonts

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -130,12 +130,18 @@
   align-items: center;
 }
 
+.hero h1,
+.hero h2 {
+  width: 100%;
+  white-space: nowrap;
+}
+
 .hero h1 {
-  font-size: clamp(2rem, 6vw, 4rem);
+  font-size: clamp(2.022rem, 6vw, 3.236rem);
 }
 
 .hero h2 {
-  font-size: clamp(1.25rem, 4vw, 2rem);
+  font-size: clamp(1.25rem, 3.708vw, 2rem);
 }
 
 .hero-content {


### PR DESCRIPTION
## Summary
- ensure hero headings stretch full width and remain on a single line
- tune hero h1/h2 font sizes to maintain a golden ratio scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976a1eb66c8330ae7240f5b85493e1