### PR TITLE
Add border around services cards

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -209,6 +209,7 @@
 /* Services */
 #services .card {
   height: 100%;
+  border: 1px solid var(--muted);
 }
 
 /* Process */


### PR DESCRIPTION
## Summary
- draw a 1px muted border around cards in the services section for better delineation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976fa01f708330aed74e8a820aa302