### PR TITLE
Update service card link size and process headings

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -212,6 +212,10 @@
   border: 1px solid var(--muted);
 }
 
+#services .card a {
+  font-size: 24px;
+}
+
 /* Process */
 .process-step {
   text-align: center;

--- a/index.html
+++ b/index.html
@@ -90,25 +90,25 @@
       <div class="row text-center">
         <div class="col-md-3">
           <div class="process-step card">
-            <h4><strong>1. Discovery</strong></h4>
+            <h4>1. Discovery</h4>
             <p>Understand client goals and perform initial analysis</p>
           </div>
         </div>
         <div class="col-md-3">
           <div class="process-step card">
-            <h4><strong>2. Strategy</strong></h4>
+            <h4>2. Strategy</h4>
             <p>Develop customized SEO roadmap</p>
           </div>
         </div>
         <div class="col-md-3">
           <div class="process-step card">
-            <h4><strong>3. Implementation</strong></h4>
+            <h4>3. Implementation</h4>
             <p>Execute strategic SEO tactics</p>
           </div>
         </div>
         <div class="col-md-3">
           <div class="process-step card">
-            <h4><strong>4. Reporting</strong></h4>
+            <h4>4. Reporting</h4>
             <p>Track performance and provide insights</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- enlarge service card links to 24px
- remove strong tags from Our Process headings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d8827cc083309488c9c0ccb91bd1