### PR TITLE
Remove font size override for service links

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -218,10 +218,6 @@
   font-family: 'Merriweather', serif;
 }
 
-#services .card a {
-  font-size: 24px;
-}
-
 /* Process */
 .process-step {
   text-align: center;


### PR DESCRIPTION
## Summary
- remove font-size override from service card links in layout.css

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897dde6ba048330a997a67de24e196f