### PR TITLE
Remove hero button hover background

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -149,6 +149,12 @@
   margin: 0 auto;
 }
 
+.hero .btn-accent:hover {
+  background: none;
+  color: var(--accent);
+  border: 1px solid var(--muted);
+}
+
 
 /* CTA Block */
 .cta-block {


### PR DESCRIPTION
## Summary
- Make hero button hover transparent, show accent text, and add muted border for subtle call-to-action styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e087d93c8330a6cea4522a716634