### PR TITLE
Remove hero padding

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -113,7 +113,7 @@
 
 /* Hero Section */
 .hero {
-  padding: var(--space-lg) var(--space-sm);
+  padding: 0;
   text-align: center;
   background-color: #111;
   /* Add a subtle overlay to improve text contrast over the background image */


### PR DESCRIPTION
## Summary
- remove default padding from hero section so content spans full viewport

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689899946da88330af35aa9f098f53bf