### PR TITLE
feat: refine dark theme panel styling

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -2,14 +2,21 @@
 body {
   font-family: var(--font-body);
   color: var(--fg);
-  background-color: var(--primary);
   margin: 0;
   padding: 0;
   line-height: 1.6;
 }
 
+html, body {
+  background-color: var(--primary);
+}
+
 main {
-  background-color: #060606;
+  background: transparent;
+}
+
+section {
+  background: transparent;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -115,7 +115,6 @@
 .hero {
   padding: 0;
   text-align: center;
-  background-color: #111;
   /* Add a subtle overlay to improve text contrast over the background image */
   background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url("../images/dark-background-muted-lines.svg");
   background-size: cover;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,3 +8,18 @@
 @import url('base.css');
 @import url('utilities.css');
 @import url('layout.css');
+
+/* Light panel on dark background */
+.card {
+  background-color: var(--panel-bg) !important;
+  border: 1px solid var(--panel-border) !important;
+  border-radius: var(--panel-radius);
+  box-shadow: var(--panel-shadow);
+  color: var(--fg);
+  padding: var(--space-md);
+}
+
+/* Headings/links inside cards remain readable and on-brand */
+.card h3, .card h4, .card h5 { color: var(--fg); margin-top: 0; }
+.card a { color: var(--fg); text-decoration: none; }
+.card a:hover { color: var(--accent); }

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -26,4 +26,8 @@
   --space-sm: 1rem;
   --space-md: 2rem;
   --space-lg: 4rem;
+  --panel-bg: rgba(255,255,255,0.05);
+  --panel-border: rgba(255,255,255,0.08);
+  --panel-shadow: 0 10px 30px rgba(0,0,0,0.35);
+  --panel-radius: 16px; /* optional, or use var(--radius) */
 }


### PR DESCRIPTION
## Summary
- centralize dark theme background to `html, body` and make `main` and `section` transparent
- introduce reusable panel tokens and light-on-dark card styling
- drop hardcoded hero background color to rely on overlay imagery

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68989eb172d88330ae264862c4c2922e