### PR TITLE
Remove background from services section cards

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -214,8 +214,10 @@
 /* Services */
 #services .card {
   height: 100%;
-  border: 1px solid var(--muted);
+  border: 1px solid var(--muted) !important;
   font-family: 'Merriweather', serif;
+  background-color: transparent !important;
+  box-shadow: none !important;
 }
 
 #services .card p,


### PR DESCRIPTION
## Summary
- Remove background and shadow from Services section cards for a cleaner look.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a3c27a88833086a82da7603a0755