### PR TITLE
Fix Services heading link font-size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -23,3 +23,7 @@
 .card h3, .card h4, .card h5 { color: var(--fg); margin-top: 0; }
 .card a { color: var(--fg); text-decoration: none; }
 .card a:hover { color: var(--accent); }
+#services h3,
+#services h3 a {
+  font-size: 20px;
+}


### PR DESCRIPTION
## Summary
- Ensure Services section h3 headings and links use the global 20px size

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa8b4ffc8330adf35050432aee3e