### PR TITLE
Add placeholder service pages and subscribe form

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,12 +9,16 @@
 @import url('utilities.css');
 @import url('layout.css');
 
-/* Light panel on dark background */
+/* Light card on dark background */
+html, body { background-color: var(--primary); }
+main { background: transparent; }
+section { background: transparent; }
+
 .card {
-  background-color: var(--panel-bg) !important;
-  border: 1px solid var(--panel-border) !important;
-  border-radius: var(--panel-radius);
-  box-shadow: var(--panel-shadow);
+  background-color: rgba(255,255,255,0.05) !important;
+  border: 1px solid rgba(255,255,255,0.08) !important;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.35);
   color: var(--fg);
   padding: var(--space-md);
 }
@@ -23,3 +27,15 @@
 .card h3, .card h4, .card h5 { color: var(--fg); margin-top: 0; }
 .card a { color: var(--fg); text-decoration: none; }
 .card a:hover { color: var(--accent); }
+
+.btn-accent {
+  display: inline-block;
+  background: var(--accent);
+  color: #111;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.btn-accent:hover { filter: brightness(0.95); }

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       </ul>
     </nav>
 
-    <a href="#contact" class="header-right nav-right">Let's Work Together</a>
+    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
   </header>
 
   <main class="container-fluid">
@@ -41,7 +41,7 @@
     <section class="hero" role="region" aria-labelledby="hero-heading">
       <h1 id="hero-heading">Strategic SEO for Sustainable Growth</h1>
       <h2>We help businesses increase visibility and organic traffic.</h2>
-      <a href="#services" class="btn-accent">Let's Work Together</a>
+      <a href="/subscribe/" class="btn-accent">Let's Work Together</a>
     </section>
   </main>
  
@@ -51,19 +51,19 @@
       <div class="row">
         <div class="col-md-4">
           <div class="card">
-            <h3><a href="#">Google Growth Jumpstart – $299</a></h3>
+            <h3><a href="/services/growth-jumpstart/">Google Growth Jumpstart – $299</a></h3>
             <p>Kickstart your site with essential optimizations and analytics setup.</p>
           </div>
         </div>
         <div class="col-md-4">
           <div class="card">
-            <h3><a href="#">SEO Clarity Report</a></h3>
+            <h3><a href="/services/seo-clarity-report/">SEO Clarity Report</a></h3>
             <p>Get a comprehensive overview of your current SEO standing.</p>
           </div>
         </div>
         <div class="col-md-4">
           <div class="card">
-            <h3><a href="#">On-page SEO</a></h3>
+            <h3><a href="/services/on-page-seo/">On-page SEO</a></h3>
             <p>Fine-tune content and structure for higher rankings.</p>
           </div>
         </div>

--- a/services/growth-jumpstart/index.html
+++ b/services/growth-jumpstart/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Google Growth Jumpstart – $299 – Coming Soon</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-left"><a href="/">H. Hill</a></div>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-menu" id="primary-menu">
+        <li class="nav-item"><a class="nav-link" href="/#services">Services</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#what-i-offer">What I Offer</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#our-process">Our Process</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#testimonials">Testimonials</a></li>
+      </ul>
+    </nav>
+    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
+  </header>
+
+  <main class="container py-5">
+    <div class="card mx-auto" style="max-width: 720px;">
+      <h1 class="mb-3">Google Growth Jumpstart – $299</h1>
+      <p class="lead mb-4">Kickstart your site with essential optimizations and analytics setup.</p>
+      <p class="text-muted mb-4">This offer is being finalized. Be first to know when it launches.</p>
+      <a class="btn-accent" href="/subscribe/">Join the Waitlist</a>
+    </div>
+  </main>
+
+  <footer class="py-5">
+    <div class="container">
+      <p>&copy; <script>document.write(new Date().getFullYear());</script> H. Hill. All Rights Reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/services/on-page-seo/index.html
+++ b/services/on-page-seo/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>On-page SEO – Coming Soon</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-left"><a href="/">H. Hill</a></div>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-menu" id="primary-menu">
+        <li class="nav-item"><a class="nav-link" href="/#services">Services</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#what-i-offer">What I Offer</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#our-process">Our Process</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#testimonials">Testimonials</a></li>
+      </ul>
+    </nav>
+    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
+  </header>
+
+  <main class="container py-5">
+    <div class="card mx-auto" style="max-width: 720px;">
+      <h1 class="mb-3">On-page SEO</h1>
+      <p class="lead mb-4">Fine-tune content and structure for higher rankings.</p>
+      <p class="text-muted mb-4">This offer is being finalized. Be first to know when it launches.</p>
+      <a class="btn-accent" href="/subscribe/">Join the Waitlist</a>
+    </div>
+  </main>
+
+  <footer class="py-5">
+    <div class="container">
+      <p>&copy; <script>document.write(new Date().getFullYear());</script> H. Hill. All Rights Reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/services/seo-clarity-report/index.html
+++ b/services/seo-clarity-report/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>SEO Clarity Report – Coming Soon</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-left"><a href="/">H. Hill</a></div>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-menu" id="primary-menu">
+        <li class="nav-item"><a class="nav-link" href="/#services">Services</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#what-i-offer">What I Offer</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#our-process">Our Process</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#testimonials">Testimonials</a></li>
+      </ul>
+    </nav>
+    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
+  </header>
+
+  <main class="container py-5">
+    <div class="card mx-auto" style="max-width: 720px;">
+      <h1 class="mb-3">SEO Clarity Report</h1>
+      <p class="lead mb-4">Get a comprehensive overview of your current SEO standing.</p>
+      <p class="text-muted mb-4">This offer is being finalized. Be first to know when it launches.</p>
+      <a class="btn-accent" href="/subscribe/">Join the Waitlist</a>
+    </div>
+  </main>
+
+  <footer class="py-5">
+    <div class="container">
+      <p>&copy; <script>document.write(new Date().getFullYear());</script> H. Hill. All Rights Reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Join the Waitlist</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-left"><a href="/">H. Hill</a></div>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-menu" id="primary-menu">
+        <li class="nav-item"><a class="nav-link" href="/#services">Services</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#what-i-offer">What I Offer</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#our-process">Our Process</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#testimonials">Testimonials</a></li>
+      </ul>
+    </nav>
+    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
+  </header>
+
+  <main class="container py-5">
+    <div class="card mx-auto" style="max-width: 640px;">
+      <h1 class="mb-2">Get Early Access</h1>
+      <p class="lead mb-4">Join the waitlist and get notified when new offers go live.</p>
+
+      <form id="subscribe-form" action="#" method="POST" novalidate>
+        <!-- TODO: replace action with Formspree/Mailchimp/ConvertKit endpoint -->
+        <div class="mb-3">
+          <label for="email" class="form-label">Email address</label>
+          <input id="email" name="email" type="email" class="form-control" placeholder="you@company.com" required />
+          <div class="invalid-feedback">Please enter a valid email.</div>
+        </div>
+        <button type="submit" class="btn-accent w-100">Join Waitlist</button>
+        <p class="mt-3 text-muted" style="font-size:.9rem;">We’ll only email about launches and key updates. No spam. Unsubscribe anytime.</p>
+      </form>
+
+      <div id="subscribe-success" class="alert alert-success mt-4 d-none" role="alert">
+        Thanks! You’re on the list — check your inbox for a confirmation.
+      </div>
+    </div>
+  </main>
+
+  <footer class="py-5">
+    <div class="container">
+      <p>&copy; <script>document.write(new Date().getFullYear());</script> H. Hill. All Rights Reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    // Lightweight client-side validation + fake success
+    const form = document.getElementById('subscribe-form');
+    const email = document.getElementById('email');
+    const success = document.getElementById('subscribe-success');
+
+    form.addEventListener('submit', function(e){
+      if (!email.value || !email.checkValidity()) {
+        e.preventDefault();
+        email.classList.add('is-invalid');
+        return;
+      }
+      if (form.getAttribute('action') === '#') {
+        e.preventDefault();
+        form.classList.add('d-none');
+        success.classList.remove('d-none');
+      }
+    });
+    email.addEventListener('input', () => email.classList.remove('is-invalid'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Coming Soon pages for Google Growth Jumpstart, SEO Clarity Report, and On-page SEO services
- create subscribe landing page with waitlist form
- wire homepage CTAs and service links to new pages and update styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aba7b1848330942b332a2a83db18