### PR TITLE
style: add spacing below hero subheading

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -141,6 +141,7 @@
 
 .hero h2 {
   font-size: clamp(1.25rem, 3.708vw, 2rem);
+  margin-bottom: var(--space-sm);
 }
 
 .hero-content {


### PR DESCRIPTION
## Summary
- add vertical margin after hero heading to separate it from call-to-action button

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898af0de708833083515f30426a048c