### PR TITLE
Make service cards fully clickable

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,3 +45,24 @@ section { background: transparent; }
   font-size: 20px;
 }
 
+/* Emphasized, accessible title links with animated underline */
+.title-link{
+  color: var(--fg);
+  text-decoration: none;
+  background-image: linear-gradient(var(--accent), var(--accent));
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 0% 2px;
+  transition: color .18s ease, background-size .18s ease;
+}
+
+.link-card:hover .title-link,
+.title-link:focus-visible{
+  color: var(--accent);
+  background-size: 100% 2px;
+}
+
+/* Make the card feel clickable and show keyboard focus */
+.link-card{ cursor: pointer; }
+.link-card:focus-within{ outline: 2px solid var(--accent); outline-offset: 3px; }
+

--- a/index.html
+++ b/index.html
@@ -50,21 +50,30 @@
       <h2>Services</h2>
       <div class="row">
         <div class="col-md-4">
-          <div class="card">
-            <h3><a href="/services/growth-jumpstart/">Google Growth Jumpstart – $299</a></h3>
+          <div class="card position-relative link-card">
+            <h3 class="card-title">
+              <a class="title-link" href="/services/growth-jumpstart/">Google Growth Jumpstart – $299</a>
+            </h3>
             <p>Kickstart your site with essential optimizations and analytics setup.</p>
+            <a class="stretched-link" href="/services/growth-jumpstart/"></a>
           </div>
         </div>
         <div class="col-md-4">
-          <div class="card">
-            <h3><a href="/services/seo-clarity-report/">SEO Clarity Report</a></h3>
+          <div class="card position-relative link-card">
+            <h3 class="card-title">
+              <a class="title-link" href="/services/seo-clarity-report/">SEO Clarity Report</a>
+            </h3>
             <p>Get a comprehensive overview of your current SEO standing.</p>
+            <a class="stretched-link" href="/services/seo-clarity-report/"></a>
           </div>
         </div>
         <div class="col-md-4">
-          <div class="card">
-            <h3><a href="/services/on-page-seo/">On-page SEO</a></h3>
+          <div class="card position-relative link-card">
+            <h3 class="card-title">
+              <a class="title-link" href="/services/on-page-seo/">On-page SEO</a>
+            </h3>
             <p>Fine-tune content and structure for higher rankings.</p>
+            <a class="stretched-link" href="/services/on-page-seo/"></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make service cards fully clickable using stretched links
- highlight card titles on hover or focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b70526408330835bf11e72d879a3