### PR TITLE
Add lift and expand animation for service cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,24 +45,79 @@ section { background: transparent; }
   font-size: 20px;
 }
 
-/* Emphasized, accessible title links with animated underline */
+/* --- Elevation & panel hover tokens (add inside :root block if present, else keep here) --- */
+:root {
+  --elev-1: 0 10px 30px rgba(0,0,0,.35);
+  --elev-2: 0 20px 40px rgba(0,0,0,.50);
+  --panel-bg-hover: rgba(255,255,255,.06);
+  --panel-border-hover: rgba(255,255,255,.16);
+}
+
+/* Ensure base elevation on cards (safe override) */
+.card { box-shadow: var(--elev-1); }
+
+/* Pro "lift & expand" animation for clickable cards */
+.link-card{
+  transform: translateZ(0); /* GPU hint */
+  transition:
+    transform .18s cubic-bezier(.2,.8,.2,1),
+    box-shadow .18s ease,
+    background-color .18s ease,
+    border-color .18s ease;
+  will-change: transform;
+  cursor: pointer;
+}
+.link-card:hover,
+.link-card:focus-within{
+  transform: scale(1.02) translateY(-2px);
+  box-shadow: var(--elev-2);
+  background-color: var(--panel-bg-hover);
+  border-color: var(--panel-border-hover);
+}
+.link-card:active{
+  transform: scale(.995) translateY(0);
+}
+
+/* Animated title underline (reliable ::after) */
 .title-link{
+  position: relative;
+  z-index: 2;                 /* stays above stretched-link overlay */
+  display: inline-block;
   color: var(--fg);
   text-decoration: none;
-  background-image: linear-gradient(var(--accent), var(--accent));
-  background-repeat: no-repeat;
-  background-position: 0 100%;
-  background-size: 0% 2px;
-  transition: color .18s ease, background-size .18s ease;
+  transition: color .18s ease;
 }
-
-.link-card:hover .title-link,
+.title-link::after{
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  height: 2px;
+  width: 0;
+  background: var(--accent);
+  transition: width .18s cubic-bezier(.2,.8,.2,1);
+}
+/* Trigger via link hover/focus OR entire card hover/focus */
+.title-link:hover,
 .title-link:focus-visible{
   color: var(--accent);
-  background-size: 100% 2px;
+}
+.title-link:hover::after,
+.title-link:focus-visible::after,
+.link-card:hover .title-link::after,
+.link-card:focus-within .title-link::after{
+  width: 100%;
 }
 
-/* Make the card feel clickable and show keyboard focus */
-.link-card{ cursor: pointer; }
+/* Keyboard accessibility */
 .link-card:focus-within{ outline: 2px solid var(--accent); outline-offset: 3px; }
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .link-card{ transition: none; transform: none; }
+  .link-card:hover,
+  .link-card:focus-within,
+  .link-card:active{ transform: none; }
+  .title-link::after{ transition: none; }
+}
 


### PR DESCRIPTION
## Summary
- introduce elevation tokens and hover animations for service cards
- add animated underline and focus styles for card titles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b9d8761c8330bbb4f08cb1539f9a