### PR TITLE
feat: use black background token

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -8,7 +8,7 @@ body {
 }
 
 html, body {
-  background-color: var(--primary);
+  background-color: var(--black);
 }
 
 main {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,7 +10,7 @@
 @import url('layout.css');
 
 /* Light card on dark background */
-html, body { background-color: var(--primary); }
+html, body { background-color: var(--black); }
 main { background: transparent; }
 section { background: transparent; }
 

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -12,6 +12,7 @@
   --muted: #999999;
   --fg: #f5f5f5;
   --bg: #0a0a0a;
+  --black: #000000;
 
   /* Typography */
   --font-body: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- add `--black` design token for pure black
- use new token for page background color

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6898d3ea21548330b764a77966ad50bb