### PR TITLE
use #111111 for black background

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -7,17 +7,8 @@ body {
   line-height: 1.6;
 }
 
-html, body {
-  background-color: var(--black);
-}
-
-main {
-  background: transparent;
-}
-
-section {
-  background: transparent;
-}
+html { background-color: var(--black); } /* single source of truth */
+body, main, section { background: transparent; }
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-display);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,9 +10,8 @@
 @import url('layout.css');
 
 /* Light card on dark background */
-html, body { background-color: var(--black); }
-main { background: transparent; }
-section { background: transparent; }
+html { background-color: var(--black); } /* single source of truth */
+body, main, section { background: transparent; }
 
 .card {
   background-color: rgba(255,255,255,0.05) !important;

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -12,7 +12,7 @@
   --muted: #999999;
   --fg: #f5f5f5;
   --bg: #0a0a0a;
-  --black: #000000;
+  --black: #111111;
 
   /* Typography */
   --font-body: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- define `--black` as `#111111`
- apply single `html` background color using the `--black` token
- keep `body`, `main`, and `section` backgrounds transparent

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d9a198fc83308a04a84c6d96cd35