### PR TITLE
Add hover focus animation to contact form inputs

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -248,11 +248,21 @@
   color: var(--fg);
   border: 1px solid var(--muted);
   border-radius: var(--radius);
+  transition: border-color 0.3s, box-shadow 0.3s;
 }
 
 #contact form input::placeholder,
 #contact form textarea::placeholder {
   color: var(--muted);
+}
+
+#contact form input:hover,
+#contact form input:focus,
+#contact form textarea:hover,
+#contact form textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(255, 184, 0, 0.3);
+  outline: none;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- animate contact form fields on hover and focus for clearer interactivity

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ddea15c48330bc7df87cc8ffbda4