### PR TITLE
Add htmx-based intake funnel

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -196,3 +196,8 @@ body, main, section { background: transparent; }
 }
 
 
+.step-shell { max-width: 900px; margin: 2rem auto; }
+.step-indicator { font-size:.9rem; color: var(--muted); margin-bottom:.5rem; border-bottom:1px solid rgba(255,255,255,.08); padding-bottom:.5rem; }
+.step-container { min-height: 320px; }
+.mini-card { padding: var(--space-sm); transition: padding .22s cubic-bezier(.2,.8,.2,1), box-shadow .22s ease; cursor:pointer; }
+.mini-card:hover { padding: calc(var(--space-sm) + .3rem); box-shadow: var(--elev-2); background: var(--panel-bg-hover); border-color: var(--panel-border-hover); }

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       </ul>
     </nav>
 
-    <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
+    <a href="/work-with-h/" class="header-right nav-right">Let's Work Together</a>
   </header>
 
   <main class="container-fluid">
@@ -41,7 +41,7 @@
     <section class="hero" role="region" aria-labelledby="hero-heading">
       <h1 id="hero-heading">Strategic SEO for Sustainable Growth</h1>
       <h2>We help businesses increase visibility and organic traffic.</h2>
-      <a href="/subscribe/" class="btn-accent">Let's Work Together</a>
+      <a href="/work-with-h/" class="btn-accent">Let's Work Together</a>
     </section>
   </main>
  

--- a/work-with-h/book/index.html
+++ b/work-with-h/book/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Book a Call</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body class="container py-5">
+  <h1>Book a 15-minute triage call</h1>
+  <p>[Scheduler placeholder]</p>
+  <p><a class="btn-accent" href="mailto:you@example.com">Email me to schedule</a></p>
+</body>
+</html>

--- a/work-with-h/index.html
+++ b/work-with-h/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Work With H</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/css/style.css">
+  <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-left">H. Hill</div>
+    <input type="checkbox" id="menu-toggle" class="menu-toggle" hidden>
+    <label for="menu-toggle" class="nav-toggle-label">
+      <span class="hamburger"></span>
+    </label>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-menu" id="primary-menu">
+        <li class="nav-item"><a class="nav-link" href="/services/">Services</a></li>
+        <li class="nav-item"><a class="nav-link" href="/resources/">Resources</a></li>
+      </ul>
+    </nav>
+    <a href="/work-with-h/" class="header-right nav-right">Let's Work Together</a>
+  </header>
+
+  <main class="container py-4">
+    <form id="intake" action="https://formspree.io/f/REPLACE_WITH_YOUR_FORM_ID" method="POST">
+      <input type="hidden" name="_redirect" id="_redirect" value="">
+      <input type="hidden" name="service" id="service" value="">
+      <input type="text" name="_gotcha" class="d-none" tabindex="-1" autocomplete="off">
+      <div class="card step-shell">
+        <div class="step-indicator"><span id="step-label">Step 1 of 3</span></div>
+        <div class="step-container" hx-get="/work-with-h/steps/step1.html" hx-trigger="load" hx-target="this" hx-swap="innerHTML">
+          <!-- htmx will load Step 1 here -->
+        </div>
+      </div>
+    </form>
+    <small class="d-block mt-3"><a href="/privacy/" class="link-light">Privacy</a></small>
+  </main>
+</body>
+</html>

--- a/work-with-h/steps/step1.html
+++ b/work-with-h/steps/step1.html
@@ -1,0 +1,34 @@
+<h2 class="mb-4">What do you need help with?</h2>
+<div class="row g-3">
+  <div class="col-md-6">
+    <button type="button" class="card mini-card w-100"
+      hx-get="/work-with-h/steps/step2-seo.html"
+      hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-seo">
+      <strong>SEO</strong><br><span class="text-muted small">More qualified traffic</span>
+    </button>
+  </div>
+  <div class="col-md-6">
+    <button type="button" class="card mini-card w-100"
+      hx-get="/work-with-h/steps/step2-coding.html"
+      hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-coding">
+      <strong>Coding</strong><br><span class="text-muted small">Apps &amp; integrations</span>
+    </button>
+  </div>
+  <div class="col-md-6">
+    <button type="button" class="card mini-card w-100"
+      hx-get="/work-with-h/steps/step2-automations.html"
+      hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-automations">
+      <strong>Automations</strong><br><span class="text-muted small">Save time, reduce errors</span>
+    </button>
+  </div>
+  <div class="col-md-6">
+    <button type="button" class="card mini-card w-100"
+      hx-get="/work-with-h/steps/step2-unsure.html"
+      hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-unsure">
+      <strong>Not sure yet</strong><br><span class="text-muted small">Let's figure it out</span>
+    </button>
+  </div>
+</div>
+<div class="d-flex justify-content-between mt-3">
+  <button type="button" class="btn btn-outline-light" disabled>Back</button>
+</div>

--- a/work-with-h/steps/step2-automations.html
+++ b/work-with-h/steps/step2-automations.html
@@ -1,0 +1,37 @@
+<input type="hidden" name="service" value="automations" id="service" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="/work-with-h/thanks/automations/" id="_redirect" hx-swap-oob="true">
+<h2 class="mb-4">Automation Project Details</h2>
+<div class="mb-3">
+  <label class="form-label">Tools involved</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="notion" required><label class="form-check-label">Notion</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="gsheets"><label class="form-check-label">Google Sheets</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="zapier"><label class="form-check-label">Zapier</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="make"><label class="form-check-label">Make</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="slack"><label class="form-check-label">Slack</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="gmail"><label class="form-check-label">Gmail</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="tradingview"><label class="form-check-label">TradingView</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="metatrader"><label class="form-check-label">MetaTrader</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="tools[]" value="other"><label class="form-check-label">Other</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label">Trigger type</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="trigger_type" value="time-based"><label class="form-check-label">Time-based</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="trigger_type" value="webhook"><label class="form-check-label">Webhook</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="trigger_type" value="manual"><label class="form-check-label">Manual</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label">Volume</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="volume" value="low"><label class="form-check-label">Low</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="volume" value="med"><label class="form-check-label">Med</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="volume" value="high"><label class="form-check-label">High</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label">Data sensitivity</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="sensitivity" value="none"><label class="form-check-label">None</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="sensitivity" value="pii"><label class="form-check-label">PII</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="sensitivity" value="contractual"><label class="form-check-label">Contractual</label></div>
+</div>
+<div class="d-flex justify-content-between mt-3">
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step1.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s1">Back</button>
+  <button type="button" class="btn-accent" hx-get="/work-with-h/steps/step3.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s3">Next</button>
+</div>

--- a/work-with-h/steps/step2-coding.html
+++ b/work-with-h/steps/step2-coding.html
@@ -1,0 +1,42 @@
+<input type="hidden" name="service" value="coding" id="service" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="/work-with-h/thanks/coding/" id="_redirect" hx-swap-oob="true">
+<h2 class="mb-4">Coding Project Details</h2>
+<div class="mb-3">
+  <label class="form-label" for="project_type">Project type</label>
+  <select class="form-select" id="project_type" name="project_type" required>
+    <option>API</option>
+    <option>Dashboard</option>
+    <option>Integration</option>
+  </select>
+</div>
+<div class="mb-3">
+  <label class="form-label">Preferred stack</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="stack_choice[]" value="python-fastapi"><label class="form-check-label">Python/FastAPI</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" name="stack_choice[]" value="react"><label class="form-check-label">React</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label" for="hosting">Hosting</label>
+  <select class="form-select" id="hosting" name="hosting">
+    <option>Docker</option>
+    <option>VPS</option>
+    <option>Cloud</option>
+  </select>
+</div>
+<div class="mb-3">
+  <label class="form-label" for="data_source">Data source</label>
+  <select class="form-select" id="data_source" name="data_source">
+    <option>Postgres</option>
+    <option>Sheets</option>
+    <option>Other</option>
+  </select>
+</div>
+<div class="mb-3">
+  <label class="form-label">Urgency</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="urgency" value="ASAP"><label class="form-check-label">ASAP</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="urgency" value="30-60"><label class="form-check-label">30–60</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="urgency" value="60-90"><label class="form-check-label">60–90</label></div>
+</div>
+<div class="d-flex justify-content-between mt-3">
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step1.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s1">Back</button>
+  <button type="button" class="btn-accent" hx-get="/work-with-h/steps/step3.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s3">Next</button>
+</div>

--- a/work-with-h/steps/step2-seo.html
+++ b/work-with-h/steps/step2-seo.html
@@ -1,0 +1,39 @@
+<input type="hidden" name="service" value="seo" id="service" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="/work-with-h/thanks/seo/" id="_redirect" hx-swap-oob="true">
+<h2 class="mb-4">SEO Project Details</h2>
+<div class="mb-3">
+  <label class="form-label" for="url">Website URL</label>
+  <input type="text" class="form-control" id="url" name="url" required>
+</div>
+<div class="mb-3">
+  <label class="form-label" for="cms">CMS</label>
+  <select class="form-select" id="cms" name="cms">
+    <option>WordPress</option>
+    <option>Shopify</option>
+    <option>Webflow</option>
+    <option>Custom</option>
+    <option>Other</option>
+  </select>
+</div>
+<div class="mb-3">
+  <label class="form-label">Primary goal</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="primary_goal" value="traffic"><label class="form-check-label">Traffic</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="primary_goal" value="leads"><label class="form-check-label">Leads</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="primary_goal" value="rankings"><label class="form-check-label">Rankings</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label">Monthly traffic</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="traffic_bucket" value="0-1k"><label class="form-check-label">0–1k</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="traffic_bucket" value="1-10k"><label class="form-check-label">1–10k</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="traffic_bucket" value="10k+"><label class="form-check-label">10k+</label></div>
+</div>
+<div class="mb-3">
+  <label class="form-label">Timeframe</label><br>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="timeframe" value="ASAP"><label class="form-check-label">ASAP</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="timeframe" value="30-60"><label class="form-check-label">30–60</label></div>
+  <div class="form-check form-check-inline"><input class="form-check-input" type="radio" name="timeframe" value="60-90"><label class="form-check-label">60–90</label></div>
+</div>
+<div class="d-flex justify-content-between mt-3">
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step1.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s1">Back</button>
+  <button type="button" class="btn-accent" hx-get="/work-with-h/steps/step3.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s3">Next</button>
+</div>

--- a/work-with-h/steps/step2-unsure.html
+++ b/work-with-h/steps/step2-unsure.html
@@ -1,0 +1,10 @@
+<input type="hidden" name="service" value="unsure" id="service" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="/work-with-h/book/" id="_redirect" hx-swap-oob="true">
+<h2 class="mb-4">Not sure yet?</h2>
+<p>Book a 15-minute triage call.</p>
+<p><a href="/work-with-h/book/" class="btn-accent">Book a call</a></p>
+<p class="mt-3">Or continue to leave your email and I'll follow up.</p>
+<div class="d-flex justify-content-between mt-3">
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step1.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s1">Back</button>
+  <button type="button" class="btn-accent" hx-get="/work-with-h/steps/step3.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s3">Next</button>
+</div>

--- a/work-with-h/steps/step3.html
+++ b/work-with-h/steps/step3.html
@@ -1,0 +1,41 @@
+<h2 class="mb-4">Tell me about you</h2>
+<div class="mb-3">
+  <label class="form-label" for="email">Email</label>
+  <input type="email" class="form-control" id="email" name="email" required>
+</div>
+<div class="mb-3">
+  <label class="form-label" for="name">Name</label>
+  <input type="text" class="form-control" id="name" name="name">
+</div>
+<div class="mb-3">
+  <label class="form-label" for="budget">Budget</label>
+  <select class="form-select" id="budget" name="budget">
+    <option>0–1k</option>
+    <option>1–3k</option>
+    <option>3–10k</option>
+    <option>10k+</option>
+  </select>
+</div>
+<div class="mb-3">
+  <label class="form-label" for="timeline">Timeline</label>
+  <select class="form-select" id="timeline" name="timeline">
+    <option>ASAP</option>
+    <option>30–60</option>
+    <option>60–90</option>
+  </select>
+</div>
+<div class="mb-3 form-check">
+  <input class="form-check-input" type="checkbox" id="access_ok" name="access_ok">
+  <label class="form-check-label" for="access_ok">I can share access later (GA/Search Console / repo)</label>
+</div>
+<div class="mb-3 form-check">
+  <input class="form-check-input" type="checkbox" id="consent" name="consent" required>
+  <label class="form-check-label" for="consent">One practical SEO email/week. Unsubscribe anytime.</label>
+</div>
+<div class="d-flex flex-wrap gap-2 mt-3">
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step2-seo.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-seo">Back to SEO</button>
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step2-coding.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-coding">Back to Coding</button>
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step2-automations.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-automations">Back to Automations</button>
+  <button type="button" class="btn btn-outline-light" hx-get="/work-with-h/steps/step2-unsure.html" hx-target=".step-container" hx-swap="innerHTML" hx-push-url="#s2-unsure">Back to Unsure</button>
+  <button type="submit" class="btn-accent ms-auto">Submit</button>
+</div>

--- a/work-with-h/thanks/automations/index.html
+++ b/work-with-h/thanks/automations/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Thanks - Automations</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body class="container py-5">
+  <h1>Thank you!</h1>
+  <p>Here's the Automation Discovery Kit to explore ideas.</p>
+  <p><a class="btn-accent" href="/assets/lead-magnets/automation-discovery-kit.pdf">Automation Discovery Kit</a></p>
+  <p><a href="#">See examples</a></p>
+  <p class="mt-4 small">Next steps: confirm tools and volume.</p>
+</body>
+</html>

--- a/work-with-h/thanks/coding/index.html
+++ b/work-with-h/thanks/coding/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Thanks - Coding</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body class="container py-5">
+  <h1>Thank you!</h1>
+  <p>Ready to scope your build? Download the worksheet.</p>
+  <p><a class="btn-accent" href="/assets/lead-magnets/api-scoping-worksheet.pdf">API Scoping Worksheet</a></p>
+  <p><a href="mailto:you@example.com">Request Google Doc</a></p>
+  <p class="mt-4 small">Next steps: share repo or brief when available.</p>
+</body>
+</html>

--- a/work-with-h/thanks/seo/index.html
+++ b/work-with-h/thanks/seo/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Thanks - SEO</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body class="container py-5">
+  <h1>Thank you!</h1>
+  <p>Your SEO inquiry is in. Grab the playbook below.</p>
+  <p><a class="btn-accent" href="/assets/lead-magnets/seo-quick-wins-playbook.pdf">Download Playbook</a></p>
+  <p><a href="/resources/seo-quick-wins/">Read web version</a></p>
+  <p class="mt-4 small">Next steps: please grant GA/Search Console access when ready.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Work With H intake funnel driven by htmx fragments
- include service-specific thank-you and booking pages
- wire homepage CTAs and helper styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e31329d88330a8d8e08b7e6485a4