### PR TITLE
Fade contact form submit hover color

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -265,6 +265,11 @@
   outline: none;
 }
 
+#contact .btn-accent:hover {
+  background-color: rgba(255, 184, 0, 0.8);
+  filter: none;
+}
+
 /* Footer */
 .site-footer {
   display: flex;


### PR DESCRIPTION
## Summary
- fade contact form submit button on hover with semi-transparent accent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e412cfa88330a2fc1107aeb1d33f