### PR TITLE
Fix redirect URL in contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
               method="POST">
 
           <!-- hidden fields required by the Worker -->
-          <input type="hidden" name="_redirect" value="/contact/thanks/">
+          <input type="hidden" name="_redirect" value="https://hhhcube.github.io/contact/thanks/">
           <input type="text" name="_gotcha" class="d-none" tabindex="-1" autocomplete="off">
           <input type="hidden" name="service" value="contact">
           <input type="hidden" name="form_name" value="homepage_contact">


### PR DESCRIPTION
## Summary
- Use full site URL in contact form `_redirect` to prevent proxy domain redirect

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfad3615c83308254d379e70f03ab