### PR TITLE
Use OOB step labels for multi-step intake fragments

### DIFF
--- a/work-with-h/steps/step1.html
+++ b/work-with-h/steps/step1.html
@@ -1,3 +1,4 @@
+<span id="step-label" hx-swap-oob="true">Step 1 of 3</span>
 <h2 class="mb-4">What do you need help with?</h2>
 <div class="row g-3">
   <div class="col-md-6">

--- a/work-with-h/steps/step2-automations.html
+++ b/work-with-h/steps/step2-automations.html
@@ -1,5 +1,6 @@
 <input type="hidden" name="service" value="automations" id="service" hx-swap-oob="true">
 <input type="hidden" name="_redirect" value="/work-with-h/thanks/automations/" id="_redirect" hx-swap-oob="true">
+<span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Automation Project Details</h2>
 <div class="mb-3">
   <label class="form-label">Tools involved</label><br>

--- a/work-with-h/steps/step2-coding.html
+++ b/work-with-h/steps/step2-coding.html
@@ -1,5 +1,6 @@
 <input type="hidden" name="service" value="coding" id="service" hx-swap-oob="true">
 <input type="hidden" name="_redirect" value="/work-with-h/thanks/coding/" id="_redirect" hx-swap-oob="true">
+<span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Coding Project Details</h2>
 <div class="mb-3">
   <label class="form-label" for="project_type">Project type</label>

--- a/work-with-h/steps/step2-seo.html
+++ b/work-with-h/steps/step2-seo.html
@@ -1,5 +1,6 @@
 <input type="hidden" name="service" value="seo" id="service" hx-swap-oob="true">
 <input type="hidden" name="_redirect" value="/work-with-h/thanks/seo/" id="_redirect" hx-swap-oob="true">
+<span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">SEO Project Details</h2>
 <div class="mb-3">
   <label class="form-label" for="url">Website URL</label>

--- a/work-with-h/steps/step2-unsure.html
+++ b/work-with-h/steps/step2-unsure.html
@@ -1,5 +1,6 @@
 <input type="hidden" name="service" value="unsure" id="service" hx-swap-oob="true">
 <input type="hidden" name="_redirect" value="/work-with-h/book/" id="_redirect" hx-swap-oob="true">
+<span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Not sure yet?</h2>
 <p>Book a 15-minute triage call.</p>
 <p><a href="/work-with-h/book/" class="btn-accent">Book a call</a></p>

--- a/work-with-h/steps/step3.html
+++ b/work-with-h/steps/step3.html
@@ -1,3 +1,4 @@
+<span id="step-label" hx-swap-oob="true">Step 3 of 3</span>
 <h2 class="mb-4">Tell me about you</h2>
 <div class="mb-3">
   <label class="form-label" for="email">Email</label>


### PR DESCRIPTION
## Summary
- Add out-of-band step labels to each step fragment so htmx updates the global progress indicator
- Include optional Step 1 label for consistency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 & sleep 1; curl -s http://localhost:8000/work-with-h/steps/step1.html | head -n 2; curl -s http://localhost:8000/work-with-h/steps/step2-coding.html | head -n 3; curl -s http://localhost:8000/work-with-h/steps/step3.html | head -n 3; pkill -f 'http.server'`

------
https://chatgpt.com/codex/tasks/task_e_689e07a79310833085583971fdaff784