### PR TITLE
Use absolute thank-you redirects and update form endpoint

### DIFF
--- a/work-with-h/index.html
+++ b/work-with-h/index.html
@@ -26,7 +26,7 @@
   </header>
 
   <main class="container py-4">
-    <form id="intake" action="https://formspree.io/f/REPLACE_WITH_YOUR_FORM_ID" method="POST">
+    <form id="intake" action="https://brevo-proxy.h3webtech.workers.dev" method="POST">
       <input type="hidden" name="_redirect" id="_redirect" value="">
       <input type="hidden" name="service" id="service" value="">
       <input type="text" name="_gotcha" class="d-none" tabindex="-1" autocomplete="off">

--- a/work-with-h/steps/step2-automations.html
+++ b/work-with-h/steps/step2-automations.html
@@ -1,5 +1,5 @@
 <input type="hidden" name="service" value="automations" id="service" hx-swap-oob="true">
-<input type="hidden" name="_redirect" value="/work-with-h/thanks/automations/" id="_redirect" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="https://hhhcube.github.io/work-with-h/thanks/automations/" id="_redirect" hx-swap-oob="true">
 <span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Automation Project Details</h2>
 <div class="mb-3">

--- a/work-with-h/steps/step2-coding.html
+++ b/work-with-h/steps/step2-coding.html
@@ -1,5 +1,5 @@
 <input type="hidden" name="service" value="coding" id="service" hx-swap-oob="true">
-<input type="hidden" name="_redirect" value="/work-with-h/thanks/coding/" id="_redirect" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="https://hhhcube.github.io/work-with-h/thanks/coding/" id="_redirect" hx-swap-oob="true">
 <span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Coding Project Details</h2>
 <div class="mb-3">

--- a/work-with-h/steps/step2-seo.html
+++ b/work-with-h/steps/step2-seo.html
@@ -1,5 +1,5 @@
 <input type="hidden" name="service" value="seo" id="service" hx-swap-oob="true">
-<input type="hidden" name="_redirect" value="/work-with-h/thanks/seo/" id="_redirect" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="https://hhhcube.github.io/work-with-h/thanks/seo/" id="_redirect" hx-swap-oob="true">
 <span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">SEO Project Details</h2>
 <div class="mb-3">

--- a/work-with-h/steps/step2-unsure.html
+++ b/work-with-h/steps/step2-unsure.html
@@ -1,5 +1,5 @@
 <input type="hidden" name="service" value="unsure" id="service" hx-swap-oob="true">
-<input type="hidden" name="_redirect" value="/work-with-h/book/" id="_redirect" hx-swap-oob="true">
+<input type="hidden" name="_redirect" value="https://hhhcube.github.io/work-with-h/book/" id="_redirect" hx-swap-oob="true">
 <span id="step-label" hx-swap-oob="true">Step 2 of 3</span>
 <h2 class="mb-4">Not sure yet?</h2>
 <p>Book a 15-minute triage call.</p>


### PR DESCRIPTION
## Summary
- Point Step 2 redirects to absolute `hhhcube.github.io` URLs so Cloudflare Worker returns users to the site.
- Post form submissions to the Brevo proxy instead of the placeholder Formspree endpoint.

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d4667108330a1bdf7c60c90add3