### PR TITLE
Revamp Google Growth Jumpstart page content and SEO

### DIFF
--- a/services/google-growth-jumpstart/index.html
+++ b/services/google-growth-jumpstart/index.html
@@ -3,8 +3,34 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Google Growth Jumpstart — $299</title>
-  <meta name="description" content="Kickstart your site with essential optimizations and analytics setup." />
+  <title>Google Growth Jumpstart – Speed, Visibility &amp; Clean Data</title>
+  <meta name="description" content="Fix your site’s biggest leaks in 7 days—no retainers, no fluff. Clean metrics, faster load times, and Google visibility for $299." />
+  <link rel="canonical" href="https://hhhcube.github.io/services/google-growth-jumpstart/">
+  <meta property="og:type" content="product">
+  <meta property="og:title" content="Google Growth Jumpstart – $299">
+  <meta property="og:description" content="7-day fix: clean data, faster pages, indexed content. No agency strings.">
+  <meta property="og:url" content="https://hhhcube.github.io/services/google-growth-jumpstart/">
+  <meta property="og:image" content="https://hhhcube.github.io/assets/img/ggj-og.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Google Growth Jumpstart – $299">
+  <meta name="twitter:description" content="7-day fix: clean data, faster pages, indexed content.">
+  <meta name="twitter:image" content="https://hhhcube.github.io/assets/img/ggj-og.jpg">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "name": "Google Growth Jumpstart",
+    "description": "A 7-day foundational fix to speed, visibility, and tracking—no agency lock-in.",
+    "brand": "H. Hill",
+    "offers": {
+      "@type": "Offer",
+      "priceCurrency": "USD",
+      "price": "299",
+      "availability": "https://schema.org/PreOrder",
+      "url": "https://hhhcube.github.io/services/google-growth-jumpstart/"
+    }
+  }
+  </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="/assets/css/style.css">
@@ -23,121 +49,63 @@
     <a href="/subscribe/" class="header-right nav-right">Let's Work Together</a>
   </header>
 
-  <main class="container py-5">
-    <div class="card ggj-card mx-auto" style="max-width: 760px;">
-      <header>
-        <h1>Google Growth Jumpstart — $299</h1>
-        <p class="lead">Kickstart your site with essential optimizations and analytics setup.</p>
-      </header>
+  <main>
+    <section class="container py-5">
+      <div class="card mx-auto" style="max-width: 980px;">
+        <h1>Google Growth Jumpstart – $299</h1>
+        <p class="lead">Your site’s biggest leaks? Fixed in 7 days.<br>Clean data. Faster pages. Indexed content. All yours—no agency strings.</p>
+        <p><a href="/contact/" class="btn-accent">Join the Waitlist</a></p>
 
-      <section aria-labelledby="value-heading" class="mt-3">
-        <h2 id="value-heading">Why it’s valuable</h2>
-        <ul>
-          <li>Fast turnaround (3 business days)</li>
-          <li>Clear deliverables</li>
-          <li>Baseline tracking</li>
+        <h2>What You Get in 7 Days</h2>
+        <ul class="lh-lg">
+          <li><strong>Trustworthy numbers</strong> – no more guessing what's working.</li>
+          <li><strong>Speed wins</strong> – faster pages mean lower bounce and more sales.</li>
+          <li><strong>Google visibility</strong> – your pages, crawled and indexed.</li>
+          <li><strong>Clarity, not clutter</strong> – one dashboard with the metrics that move the needle.</li>
+          <li><strong>Next moves mapped</strong> – a 30-day action plan ranked by ROI.</li>
         </ul>
-      </section>
+        <p>No jargon. No mystery tools. You keep full control.</p>
 
-      <section aria-labelledby="included-heading">
-        <h2 id="included-heading">What’s Included</h2>
-        <ul>
-          <li>GA4 + GSC setup/verify, sitemap submit</li>
-          <li>Title/description fixes on up to 3 key pages</li>
-          <li>404 → 301 for top broken URLs (up to 5)</li>
-          <li>Robots.txt &amp; canonical sanity check</li>
-          <li>Image hygiene: dimensions + compression guidance</li>
-          <li>Baseline report (traffic, top queries, pages)</li>
+        <h2>Why This Matters</h2>
+        <p>If your tracking’s broken, your growth is fake.<br>
+           If your site’s slow, users bounce—and Google drops you.<br>
+           If your pages aren’t indexable, they don’t exist.</p>
+        <p>You can’t scale chaos.<br>Fix the foundation. Then grow.</p>
+
+        <h2>How It Works</h2>
+        <ol class="lh-lg">
+          <li><strong>Quick Access &amp; Scan</strong> — We onboard in hours, not days. You get a plain-English health check.</li>
+          <li><strong>High-Impact Fixes</strong> — We handle the essentials—speed, visibility, measurement. You stay informed, not overwhelmed.</li>
+          <li><strong>Final Handoff</strong> — Proof-of-work, a custom dashboard, and your 30-day roadmap. You’re set to grow.</li>
+        </ol>
+
+        <h2>Who It’s For</h2>
+        <ul class="lh-lg">
+          <li>Owners tired of flying blind.</li>
+          <li>Sites spending on ads/SEO with no clean data.</li>
+          <li>Teams that want clarity—fast.</li>
         </ul>
-      </section>
+        <p><em>Not for:</em> enterprise rebuilds, giant data stacks, or anyone allergic to speed.</p>
 
-      <section aria-labelledby="need-heading">
-        <h2 id="need-heading">What I need from you</h2>
-        <ul>
-          <li>Site/CMS access (or collaborator)</li>
-          <li>GA &amp; GSC access (or invite)</li>
-          <li>Primary goal (traffic, leads, rankings)</li>
+        <h2>No Risks. Just Results.</h2>
+        <ul class="lh-lg">
+          <li>You keep the keys – full admin stays yours.</li>
+          <li>Flat fee – no contracts, no upsells.</li>
+          <li>Security-first – least-access, removed at handoff.</li>
+          <li>Guarantee – No verified improvements in 7 days? You get a refund. No back-and-forth.</li>
         </ul>
-      </section>
 
-      <section aria-labelledby="who-heading">
-        <h2 id="who-heading">Who it’s for / not for</h2>
-        <p><strong>For:</strong> new sites, small teams, stalled organic</p>
-        <p><strong>Not for:</strong> enterprise migrations or full-site rebuilds</p>
-      </section>
+        <p class="mt-3">
+          <a href="/contact/" class="btn-accent">Join the Waitlist</a>
+        </p>
 
-      <section aria-labelledby="cta-heading">
-        <h2 id="cta-heading">Tell me about your site</h2>
-        <form id="ggj-form"
-              action="https://brevo-proxy.h3webtech.workers.dev"
-              method="POST" class="mt-3">
-
-          <!-- required for Worker/Brevo -->
-          <input type="hidden" name="service" value="google_jumpstart">
-          <input type="hidden" name="form_name" value="ggj_service_page">
-          <input type="hidden" name="_redirect" value="https://hhhcube.github.io/services/google-growth-jumpstart/thanks/">
-          <input type="text"   name="_gotcha" class="d-none" tabindex="-1" autocomplete="off">
-
-          <div class="mb-3">
-            <label for="gj-name" class="form-label">Name</label>
-            <input id="gj-name" name="name" type="text" class="form-control" placeholder="Your Name">
-          </div>
-
-          <div class="mb-3">
-            <label for="gj-email" class="form-label">Email</label>
-            <input id="gj-email" name="email" type="email" class="form-control" placeholder="you@company.com" required>
-          </div>
-
-          <div class="mb-3">
-            <label for="gj-url" class="form-label">Website URL</label>
-            <input id="gj-url" name="url" type="url" class="form-control" placeholder="https://example.com" required>
-          </div>
-
-          <div class="row">
-            <div class="col-md-6 mb-3">
-              <label for="gj-goal" class="form-label">Primary goal</label>
-              <select id="gj-goal" name="goal" class="form-select">
-                <option value="traffic">Traffic</option>
-                <option value="leads">Leads</option>
-                <option value="rankings">Rankings</option>
-              </select>
-            </div>
-            <div class="col-md-6 mb-3">
-              <label for="gj-timeline" class="form-label">Timeline</label>
-              <select id="gj-timeline" name="timeline" class="form-select">
-                <option value="ASAP">ASAP</option>
-                <option value="30-60">30–60 days</option>
-                <option value="60-90">60–90 days</option>
-              </select>
-            </div>
-          </div>
-
-          <div class="mb-3">
-            <label for="gj-msg" class="form-label">What’s the biggest blocker?</label>
-            <textarea id="gj-msg" name="message" rows="4" class="form-control" placeholder="Briefly describe the situation…"></textarea>
-          </div>
-
-          <div class="form-check mb-3">
-            <input class="form-check-input" type="checkbox" id="gj-consent" name="consent" required>
-            <label class="form-check-label" for="gj-consent">
-              I agree to be contacted about this service.
-            </label>
-          </div>
-
-          <button type="submit" class="btn-accent">Request Details</button>
-        </form>
-      </section>
-
-      <section aria-labelledby="faq-heading">
-        <h2 id="faq-heading">FAQ</h2>
-        <h3>Will you spam me?</h3>
-        <p>No. You’ll only receive messages related to this request.</p>
-        <h3>What tools do you use?</h3>
-        <p>Google Analytics 4 and Google Search Console for setup and baselines. We’ll use lightweight utilities for 404s and on-page checks.</p>
-        <h3>What happens next?</h3>
-        <p>I’ll review your details, confirm scope, and share next steps and a kickoff timeline.</p>
-      </section>
-    </div>
+        <h2>FAQ</h2>
+        <details><summary>How fast is this?</summary><p>7 days from the moment we have access.</p></details>
+        <details><summary>Do you rewrite my whole site?</summary><p>Only the essentials—speed, visibility, tracking. Bigger issues go in your roadmap.</p></details>
+        <details><summary>What if I need a dev?</summary><p>If your theme fights us, we hand over exact snippets/tasks your dev can plug in fast.</p></details>
+        <details><summary>Is this for ecommerce?</summary><p>Yes. We clean up conversion tracking and events. Advanced funnels come next.</p></details>
+      </div>
+    </section>
   </main>
 
   <footer class="py-5">
@@ -145,6 +113,18 @@
       <p><span hx-get="/year" hx-trigger="load" hx-swap="outerHTML">&copy; YEAR_PLACEHOLDER</span> H. Hill. All Rights Reserved.</p>
     </div>
   </footer>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {"@type":"Question","name":"How fast is this?","acceptedAnswer":{"@type":"Answer","text":"7 days from the moment we have access."}},
+      {"@type":"Question","name":"Do you rewrite my whole site?","acceptedAnswer":{"@type":"Answer","text":"Only the essentials—speed, visibility, tracking. Bigger issues go in your roadmap."}},
+      {"@type":"Question","name":"What if I need a dev?","acceptedAnswer":{"@type":"Answer","text":"If your theme fights us, we hand over exact snippets/tasks your dev can plug in fast."}},
+      {"@type":"Question","name":"Is this for ecommerce?","acceptedAnswer":{"@type":"Answer","text":"Yes. We clean up conversion tracking and events. Advanced funnels come next."}}
+    ]
+  }
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Replace head metadata with detailed SEO tags, canonical link, and product schema
- Rewrite main body content with new offer copy and CTAs
- Append FAQPage JSON-LD for richer search results

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bac332d3208330963cd6e7c937f2bd