### PR TITLE
Refactor button utilities to use highlight color

### DIFF
--- a/assets/css/utilities.css
+++ b/assets/css/utilities.css
@@ -19,37 +19,61 @@
   box-shadow: var(--shadow);
 }
 
-.btn-accent {
+/* Base */
+.btn-accent, .btn-highlight {
   display: inline-block;
-  background-color: var(--accent);
-  color: var(--primary);
   padding: 0.75rem 1.5rem;
-  border: none;
   border-radius: var(--radius);
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
   cursor: pointer;
-  transition: background 0.3s ease;
+  transition: background-color .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+/* Keep link color stable vs global a:hover */
+.btn-accent:link, .btn-accent:visited,
+.btn-highlight:link, .btn-highlight:visited {
   text-decoration: none;
 }
 
-.btn-accent:hover {
+/* Style 1: Outline → Fill on hover */
+.btn-accent {
+  background: transparent;
+  color: var(--highlight);
+  border: 1px solid var(--muted);
+}
+.btn-accent:hover,
+.btn-accent:focus-visible {
   background-color: var(--highlight);
+  color: var(--primary);
+  border-color: transparent;
+}
+.btn-accent:active {
+  background-color: color-mix(in srgb, var(--highlight) 85%, var(--primary) 15%);
+  color: var(--primary);
 }
 
+/* Style 2: Fill → Outline on hover */
 .btn-highlight {
-  display: inline-block;
   background-color: var(--highlight);
-  color: var(--fg);
-  padding: 0.75rem 1.5rem;
+  color: var(--primary);
   border: none;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all 0.3s ease;
 }
-
-.btn-highlight:hover {
+.btn-highlight:hover,
+.btn-highlight:focus-visible {
   background: none;
   border: 1px solid var(--muted);
   color: var(--primary);
+}
+.btn-highlight:active {
+  background-color: color-mix(in srgb, var(--highlight) 85%, var(--primary) 15%);
+  color: var(--primary);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .btn-accent, .btn-highlight { transition: none; }
 }
 
 /* Responsive spacing (examples only) */


### PR DESCRIPTION
## Summary
- standardize `.btn-accent` and `.btn-highlight` utilities around `--highlight`
- implement outline-to-fill and fill-to-outline hover styles with reduced-motion fallback
- remove `--accent` references from button rules

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bac7aa53c88330a8fc0ce3e5f93998